### PR TITLE
Filter todos by an assignee

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It makes use of `astitodo` underneath.
  - [x] Fast browsing of todos.
  - [ ] Todos
 	- [x] View all todos in a specific file with `:Godo`.
-	- [ ] View todos in a file sorted by assignees with `:Godo assignee_name` (e.g `:Godo adelowo` .)
+	- [x] View todos in a file sorted by assignees with `:Godo assignee_name` (e.g `:Godo adelowo` .)
 	- [ ] Find all todos in the current folder opened.
 	- [ ] Navigate to the source code line housing the todo message.
 	- [x] Show a nice warning message if there aren't any todo in the file.
@@ -65,7 +65,13 @@ To view todos in a file, open a file buffer and `:Godo` in command mode.. To map
 
 ```vim
 
-nnoremap <Leader>. :call go#godo#Godo()<CR>
+nmap <Leader>. :Godo<CR>
+```
+
+To filter todos in a file by assignees, you make use of `:Godo assignee_name`.
+
+```vim
+:Godo adelowo " Would show all todos assigned to adelowo
 ```
 
 #### License

--- a/autoload/go/godo.vim
+++ b/autoload/go/godo.vim
@@ -1,17 +1,43 @@
-function! go#godo#Godo()
+function! go#godo#Godo(...)
+
+	let l:assignee = ""
 	let s:valid_ext = "go"
 	let err = go#utils#HasAstitodo()
-	
+
+	if a:0 == 1 && !empty(a:1)
+		" Pick out the first args alone and see if todos need to be
+		" filtered by an assignee
+		" TODO(adelowo) Support multiple assignees ? :Godo a1 a2 a3 ?
+		let l:assignee = a:1
+	endif
+
 	if err != 0 
 		echohl Error | echomsg "Please install the astitodo library by running :GodoInstallBinary" | echohl None
 		return -1
 	endif
 
 	if expand('%:e') ==# s:valid_ext
-		let l:out = system("astitodo ". expand("%"))
-	
+
+		let l:cmd = "astitodo"
+
+		if !empty(l:assignee)
+			let l:cmd .= " -a=".l:assignee.""
+		endif
+
+		let l:cmd .= " " . expand("%")
+
+		let l:out = system(l:cmd)
+
 		if l:out == ""
-			echohl WarningMessage | echo "There are no todos in this file" | echohl None
+			let l:message = "There are no todos"
+
+			" Properly format error messages for todo searches
+			" with an assignee
+			if !empty(l:assignee)
+				let l:message .= " assigned to " . l:assignee
+			endif
+
+			echohl WarningMessage | echo l:message | echohl None
 			return 0
 		endif
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -1,2 +1,2 @@
-command! -nargs=0 Godo call go#godo#Godo()
+command! -nargs=? Godo call go#godo#Godo(<f-args>)
 

--- a/plugin/godo.vim
+++ b/plugin/godo.vim
@@ -2,7 +2,7 @@ command! GodoInstallBinary call s:GodoInstallBinary(-1)
 command! GodoUpdateBinary call s:GodoInstallBinary(1)
 
 let s:astitodo = "astitodo"
-let s:astitodo_repo = "github.com/asticode/go-astitodo"
+let s:astitodo_repo = "github.com/asticode/go-astitodo/..."
 
 if !exists("g:godo_install_verbose")
 	let g:godo_install_verbose = 0


### PR DESCRIPTION
This PR updates the `:Godo` command to take an optional arg which is the assignee name, then todos belonging only to that assignees are shown...

```vim
:Godo adelowo 
:Godo " runnnig this without an assignee still works but it shows all todos in the file
```

> To assign a user to a todo in Go, you do `TODO(adelowo)` 