### PR TITLE
Filter todos by multiple assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It makes use of `astitodo` underneath.
  - [ ] Todos
 	- [x] View all todos in a specific file with `:Godo`.
 	- [x] View todos in a file sorted by assignees with `:Godo assignee_name` (e.g `:Godo adelowo` .)
+	- [x] View todos sorted by multiple assignees with `:Godo assignee_name1 assignee_name2`
 	- [ ] Find all todos in the current folder opened.
 	- [ ] Navigate to the source code line housing the todo message.
 	- [x] Show a nice warning message if there aren't any todo in the file.
@@ -72,6 +73,8 @@ To filter todos in a file by assignees, you make use of `:Godo assignee_name`.
 
 ```vim
 :Godo adelowo " Would show all todos assigned to adelowo
+
+:Godo adelowo lanre username " Would show all todos assigned to the specificied usernames
 ```
 
 #### License

--- a/autoload/go/godo.vim
+++ b/autoload/go/godo.vim
@@ -1,27 +1,28 @@
 function! go#godo#Godo(...)
 
-	let l:assignee = ""
+	let l:assignees = ""
 	let s:valid_ext = "go"
 	let err = go#utils#HasAstitodo()
-
-	if a:0 == 1 && !empty(a:1)
-		" Pick out the first args alone and see if todos need to be
-		" filtered by an assignee
-		" TODO(adelowo) Support multiple assignees ? :Godo a1 a2 a3 ?
-		let l:assignee = a:1
-	endif
 
 	if err != 0 
 		echohl Error | echomsg "Please install the astitodo library by running :GodoInstallBinary" | echohl None
 		return -1
 	endif
 
+	if a:0 > 0
+		let l:idx = 0
+		while l:idx < a:0
+			let l:assignees = l:assignees . "," . a:000[idx]
+			let l:idx = l:idx + 1
+		endwhile
+	endif
+
 	if expand('%:e') ==# s:valid_ext
 
 		let l:cmd = "astitodo"
 
-		if !empty(l:assignee)
-			let l:cmd .= " -a=".l:assignee.""
+		if !empty(l:assignees)
+			let l:cmd .= " -a=".l:assignees.""
 		endif
 
 		let l:cmd .= " " . expand("%")
@@ -33,8 +34,8 @@ function! go#godo#Godo(...)
 
 			" Properly format error messages for todo searches
 			" with an assignee
-			if !empty(l:assignee)
-				let l:message .= " assigned to " . l:assignee
+			if !empty(l:assignees)
+				let l:message .= " assigned to " . l:assignees
 			endif
 
 			echohl WarningMessage | echo l:message | echohl None

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -1,2 +1,2 @@
-command! -nargs=? Godo call go#godo#Godo(<f-args>)
+command! -nargs=* Godo call go#godo#Godo(<f-args>)
 


### PR DESCRIPTION
This PR allows the `:Godo` command accept multiple assignees.. Currently, it accepts 0 or 1 args, if 1 arg, filter by that assignee. But this PR improves on that by allowing it accept 0,1,2,X args

```vim
:Godo adelowo lanre lanre
```